### PR TITLE
Custom error messages when running with input

### DIFF
--- a/src/global/BaseTest.java
+++ b/src/global/BaseTest.java
@@ -192,6 +192,7 @@ public abstract class BaseTest {
     public void setUp() throws InvalidClauseException, InvalidTestOptionException {
         setRegexSentence(testSentence());
         TestOption.validate();  // check that test options were set with valid options
+        TestOption.resetIncorrectStructureErrorMessage();
         refreshOutputStream();
 
         if (TestOption.isInputTest) {
@@ -206,7 +207,7 @@ public abstract class BaseTest {
     public void outputFollowsCorrectStructure() {
         String output = getOutput();
         Matcher matcher = getMatches(output, processRegexForPrintlnOutput(combineRegex(getRegexSentence())));
-        String incorrectOutputMessage = "Your code's output did not follow the correct structure/syntax.";
+        String incorrectOutputMessage = TestOption.incorrectStructureErrorMessage;
        _assertTrue(matcher.find(), incorrectOutputMessage, parseTestInformation(output, getRegexSentence(), incorrectOutputMessage));
         //Ensures that the output matches the pattern exactly
         assertEquals(output.substring(matcher.start(), matcher.end()), output, incorrectOutputMessage);

--- a/src/global/tools/TestOption.java
+++ b/src/global/tools/TestOption.java
@@ -5,6 +5,7 @@ import global.exceptions.InvalidTestOptionException;
 public class TestOption {
     public static boolean isInputTest = false;
     public static String defaultInput = null;
+    public static String incorrectStructureErrorMessage = null;
 
     public static void validate() throws InvalidTestOptionException {
         // TODO: catch these errors somewhere and make sure they are only logged to the devs and not returned to the user.
@@ -16,5 +17,9 @@ public class TestOption {
         if(defaultInput != null && !isInputTest) {
             throw new InvalidTestOptionException("You have defined a defaultInput without setting TestOption.isInputTest = true.");
         }
+    }
+
+    public static void resetIncorrectStructureErrorMessage() {
+        TestOption.incorrectStructureErrorMessage = "Your code's output did not follow the correct structure/syntax.";
     }
 }


### PR DESCRIPTION
+ manage the default structure error message in the test option class
+ reset to the default message before each test
+ allow test writers to define a custom error message for a test

Closes #120 