### PR TITLE
Added additional functionality to MethodUtil

### DIFF
--- a/src/global/BaseTest.java
+++ b/src/global/BaseTest.java
@@ -192,7 +192,7 @@ public abstract class BaseTest {
     public void setUp() throws InvalidClauseException, InvalidTestOptionException {
         setRegexSentence(testSentence());
         TestOption.validate();  // check that test options were set with valid options
-        TestOption.resetIncorrectStructureErrorMessage();
+        TestOption.reset();
         refreshOutputStream();
 
         if (TestOption.isInputTest) {

--- a/src/global/tools/TestOption.java
+++ b/src/global/tools/TestOption.java
@@ -6,20 +6,23 @@ public class TestOption {
     public static boolean isInputTest = false;
     public static String defaultInput = null;
     public static String incorrectStructureErrorMessage = null;
+    public static String invalidMethodMessage = null;
 
     public static void validate() throws InvalidTestOptionException {
         // TODO: catch these errors somewhere and make sure they are only logged to the devs and not returned to the user.
         // validate that options are valid
-        if(isInputTest && defaultInput == null) {
+        if (isInputTest && defaultInput == null) {
             throw new InvalidTestOptionException("Input tests must define a TestOption.defaultInput.");
         }
 
-        if(defaultInput != null && !isInputTest) {
+        if (defaultInput != null && !isInputTest) {
             throw new InvalidTestOptionException("You have defined a defaultInput without setting TestOption.isInputTest = true.");
         }
     }
 
-    public static void resetIncorrectStructureErrorMessage() {
+    public static void reset() {
+        // This method resets all TestOptions which are test specific and could change every test
         TestOption.incorrectStructureErrorMessage = "Your code's output did not follow the correct structure/syntax.";
+        TestOption.invalidMethodMessage = null;
     }
 }

--- a/src/global/utils/MethodUtil.java
+++ b/src/global/utils/MethodUtil.java
@@ -28,17 +28,7 @@ public class MethodUtil {
     }
 
     public static Object invokeIfMethodExists(Class<?> methodClass, String methodName) {
-        setUpMethodOutput();
-        try {
-            Method testMethodInvoke = methodClass.getMethod(methodName);
-            return testMethodInvoke.invoke(null);
-        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-            fail(Objects.requireNonNullElseGet(
-                    TestOption.invalidMethodMessage,
-                    () -> String.join("", methodClass.getSimpleName(), " does not contain method ", methodName, "."))
-            );
-            return null;
-        }
+        return invokeIfMethodExists(methodClass, methodName, null, null);
     }
 
     private static void setUpMethodOutput() {

--- a/src/global/utils/MethodUtil.java
+++ b/src/global/utils/MethodUtil.java
@@ -1,32 +1,52 @@
 package global.utils;
 
+import global.tools.TestOption;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class MethodUtil {
     private static ByteArrayOutputStream methodOutput;
 
-    public static Object invokeIfMethodExists(Class<?> methodClass, String methodName, String failMessage, Object[] arguments, Class<?> ... methodArgumentTypes){
+    public static Object invokeIfMethodExists(Class<?> methodClass, String methodName, Object[] arguments, Class<?>... methodArgumentTypes) {
         setUpMethodOutput();
-            try {
-                Method testMethodInvoke = methodClass.getMethod(methodName, methodArgumentTypes);
-                return testMethodInvoke.invoke(null, arguments);
-            } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-                fail(failMessage);
-                return null;
-            }
+        try {
+            Method testMethodInvoke = methodClass.getMethod(methodName, methodArgumentTypes);
+            return testMethodInvoke.invoke(null, arguments);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            fail(Objects.requireNonNullElseGet(
+                    TestOption.invalidMethodMessage,
+                    () -> String.join("", methodClass.getSimpleName(), " does not contain method ", methodName, "."))
+            );
+            return null;
+        }
     }
 
-    private static void setUpMethodOutput(){
+    public static Object invokeIfMethodExists(Class<?> methodClass, String methodName) {
+        setUpMethodOutput();
+        try {
+            Method testMethodInvoke = methodClass.getMethod(methodName);
+            return testMethodInvoke.invoke(null);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            fail(Objects.requireNonNullElseGet(
+                    TestOption.invalidMethodMessage,
+                    () -> String.join("", methodClass.getSimpleName(), " does not contain method ", methodName, "."))
+            );
+            return null;
+        }
+    }
+
+    private static void setUpMethodOutput() {
         methodOutput = new ByteArrayOutputStream();
         System.setOut(new PrintStream(methodOutput));
     }
 
-    public static String getMethodOutput(){
+    public static String getMethodOutput() {
         return methodOutput.toString().trim();
     }
 }

--- a/src/test/MethodCodeTest.java
+++ b/src/test/MethodCodeTest.java
@@ -47,7 +47,7 @@ public class MethodCodeTest extends BaseTest {
 
     @Test
     void testOutput(){
-        MethodUtil.invokeIfMethodExists(MethodCode.class, "printSomething", "Fail", null, null);
+        MethodUtil.invokeIfMethodExists(MethodCode.class, "printSomething");
         String s = MethodUtil.getMethodOutput();
         assertEquals(s, "Print something", "Failed at assert");
     }
@@ -55,15 +55,22 @@ public class MethodCodeTest extends BaseTest {
     @Test
     void testWithInput(){
         provideInput("print this");
-        MethodUtil.invokeIfMethodExists(MethodCode.class, "printThis", "Fail", null, null);
+        TestOption.invalidMethodMessage = "Fail";
+        MethodUtil.invokeIfMethodExists(MethodCode.class, "printThis");
         String s = MethodUtil.getMethodOutput();
         assertEquals(s, "print this", "Failed at assert");
     }
 
     @Test
     void checkGetMethodOutput(){
-        double f = (double) MethodUtil.invokeIfMethodExists(MethodCode.class, "max", "Invoke failed", new Object[]{5, 9}, int.class, int.class);
+        TestOption.invalidMethodMessage = "Invoke failed";
+        double f = (double) MethodUtil.invokeIfMethodExists(MethodCode.class, "max", new Object[]{5, 9}, int.class, int.class);
         String s = MethodUtil.getMethodOutput();
         assertEquals(f, 9.0, "Assert failed");
+    }
+
+    @Test
+    void testIfTestOptionResets(){
+        MethodUtil.invokeIfMethodExists(MethodCode.class, "ThisMethod");
     }
 }


### PR DESCRIPTION
… easier, and added support for custom fail messages for invalid methods

## PR Checklist
- [ ]  Are helper methods really needed here?
    > Opt for hardcoding input/output into the input provider when possible
- [ ]  Are the assertion fail messages good?
    - [ ]  Logical (does it make sense?)
    - [ ]  Readable (can a student understand what’s wrong?)
    - [ ]  Not too feed-y (does it give away the answer?)
    - [ ]  Grammatically sound (is the grammar and punctuation in the sentence proper?)
    - [ ]  Specific (does the fail message relate to the question?)
- [ ]  Is the code formatted well?
    > Run `CTRL` + `ALT` + `L` in IntelliJ
- [ ]  EOF newlines
- [ ]  Do the comments for Parsons follow the correct convention?
- [ ]  Is the question being tested sufficiently?
    - [ ]  Are there representative cases to test the program?
    - [ ]  What about edge cases? (empty strings, negatives, infinity, etc)
        > If the question doesn’t specify what to do, mark it as a bad question
---

## Not yet, but soon

- [ ]  Are the test method names good?
    > Test method names show up in a “What went well” section on the website, so “mathTest” will become “What went well: math test”, which doesn’t make much sense. A better name in this example would be “calculatesTaxCorrectly” so it shows up as “What went well: calculates tax correctly”
