### PR TITLE
loops-nested_loops-hard-q4-fixes

### DIFF
--- a/src/loops/nested_loops/hard/q4/MainTest.java
+++ b/src/loops/nested_loops/hard/q4/MainTest.java
@@ -63,7 +63,7 @@ public class MainTest extends BaseTest {
     }
 
     static Stream<Integer> invalidInputProvider(){
-        return Stream.of(-1, -2, -344);
+        return Stream.of(-1, -2, -344, 10, 11, 4532);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Added cases to question to make sure students were properly checking the condition that numbers must be between 0 and 9 inclusive. 