### PR TITLE
arrays-arrays_with_methods-medium-q8-fix

### DIFF
--- a/src/arrays/arrays_with_methods/medium/q8/MainTest.java
+++ b/src/arrays/arrays_with_methods/medium/q8/MainTest.java
@@ -1,16 +1,16 @@
 package arrays.arrays_with_methods.medium.q8;
 
+import global.MethodTest;
 import global.tools.CustomAssertions;
-import global.utils.MethodUtil;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Arrays;
 import java.util.stream.Stream;
 
 public class MainTest {
     // Parsons
+
     static Stream<Arguments> inputProvider() {
         return Stream.of(
                 Arguments.of(0, 's', new char[][]{}),
@@ -41,7 +41,12 @@ public class MainTest {
     @ParameterizedTest
     @MethodSource("inputProvider")
     void correctMapThePatternMethod(int n, char c, char[][] arr) throws Throwable {
-        Object output = MethodUtil.invokeIfMethodExists(PatternMaker.class, "mapThePattern", new Object[]{n, c}, int.class, char.class);
+        Object[][] arguments = {
+                {n, int.class},
+                {c, char.class}
+        };
+        MethodTest m = new MethodTest(PatternMaker.class, "mapThePattern", arguments);
+        Object output = m.callMethod();
         CustomAssertions._assertArrayEquals(arr, output, "Your mapThePattern method does not correctly generate the pattern for the specified character.");
     }
 }


### PR DESCRIPTION
## PR Checklist
- [x]  Are helper methods really needed here?
    > Opt for hardcoding input/output into the input provider when possible
- [x]  Are the assertion fail messages good?
    - [x]  Logical (does it make sense?)
    - [x]  Readable (can a student understand what’s wrong?)
    - [x]  Not too feed-y (does it give away the answer?)
    - [x]  Grammatically sound (is the grammar and punctuation in the sentence proper?)
    - [x]  Specific (does the fail message relate to the question?)
- [x]  Is the code formatted well?
    > Run `CTRL` + `ALT` + `L` in IntelliJ
- [x]  EOF newlines
- [x]  Do the comments for Parsons follow the correct convention?
- [x]  Is the question being tested sufficiently?
    - [x]  Are there representative cases to test the program?
    - [x]  What about edge cases? (empty strings, negatives, infinity, off-by-one errors, etc)
        > If the question doesn’t specify what to do, mark it as a bad question
- [x]  Are the test method names good?
    > Test method names show up in a “What went well” section on the website, so “mathTest” will become “What went well: math test”, which doesn’t make much sense. A better name in this example would be “calculatesTaxCorrectly” so it shows up as “What went well: calculates tax correctly”
---
## Website
- [x] Is the question text on the Gamification document up to date? 
    > Make sure to include the sample output if there is one for the question
