### PR TITLE
loops-nested_loops-hard-q5-fix

### DIFF
--- a/src/loops/nested_loops/hard/q5/MainTest.java
+++ b/src/loops/nested_loops/hard/q5/MainTest.java
@@ -35,7 +35,7 @@ public class MainTest extends BaseTest {
     }
 
     static Stream<Integer> invalidInputProvider() {
-        return Stream.of(-1, -2, -10, -12643);
+        return Stream.of(0, -1, -2, -10, -12643);
     }
 
     @ParameterizedTest
@@ -49,8 +49,11 @@ public class MainTest extends BaseTest {
     @MethodSource("invalidInputProvider")
     void printsErrorMessageForInvalidInput(int input) throws InvalidClauseException {
         TestOption.incorrectStructureErrorMessage = "Your program does not print an error message for invalid input.";
+        //0 case added in here as well so that if the user marks 0 as invalid input this test will fail and users will
+        //have a clearer idea of where the issue is
+        String s = input == 0 ? "" : "Invalid input!";
         runWithInput(String.valueOf(input), new Clause[]{
-                new StringLiteral("Invalid input!")
+                new StringLiteral(s)
         });
     }
 


### PR DESCRIPTION
## PR Checklist
- [x]  Are helper methods really needed here?
    > Opt for hardcoding input/output into the input provider when possible
- [x]  Are the assertion fail messages good?
    - [x]  Logical (does it make sense?)
    - [x]  Readable (can a student understand what’s wrong?)
    - [x]  Not too feed-y (does it give away the answer?)
    - [x]  Grammatically sound (is the grammar and punctuation in the sentence proper?)
    - [x]  Specific (does the fail message relate to the question?)
- [x]  Is the code formatted well?
    > Run `CTRL` + `ALT` + `L` in IntelliJ
- [x]  EOF newlines
- [x]  Do the comments for Parsons follow the correct convention?
- [x]  Is the question being tested sufficiently?
    - [x]  Are there representative cases to test the program?
    - [x]  What about edge cases? (empty strings, negatives, infinity, off-by-one errors, etc)
        > If the question doesn’t specify what to do, mark it as a bad question
- [x]  Are the test method names good?
    > Test method names show up in a “What went well” section on the website, so “mathTest” will become “What went well: math test”, which doesn’t make much sense. A better name in this example would be “calculatesTaxCorrectly” so it shows up as “What went well: calculates tax correctly”
