### PR TITLE
loops-nested_loops-hard-q7-fix

### DIFF
--- a/src/loops/nested_loops/hard/q7/MainTest.java
+++ b/src/loops/nested_loops/hard/q7/MainTest.java
@@ -39,14 +39,17 @@ public class MainTest extends BaseTest {
         runWithInput(String.valueOf(n), clauseBuilder(n));
     }
 
-    static Stream<Integer> invalidInputProvider(){return Stream.of(-1, -47, -300);}
+    static Stream<Integer> invalidInputProvider(){return Stream.of(0, -1, -47, -300);}
 
     @ParameterizedTest
     @MethodSource("invalidInputProvider")
     void identifiesInvalidInput(int in) throws InvalidClauseException{
         TestOption.incorrectStructureErrorMessage = "Your program does not identify invalid input.";
+        //0 case added in here as well so that if the user marks 0 as invalid input this test will fail and users will
+        //have a clearer idea of where the issue is
+        String s = in == 0 ? "" : "Invalid input!";
         runWithInput(String.valueOf(in), new Clause[]{
-                new StringLiteral("Invalid input!")
+                new StringLiteral(s)
         });
     }
 


### PR DESCRIPTION
## PR Checklist
- [x]  Are helper methods really needed here?
    > Opt for hardcoding input/output into the input provider when possible
- [x]  Are the assertion fail messages good?
    - [x]  Logical (does it make sense?)
    - [x]  Readable (can a student understand what’s wrong?)
    - [x]  Not too feed-y (does it give away the answer?)
    - [x]  Grammatically sound (is the grammar and punctuation in the sentence proper?)
    - [x]  Specific (does the fail message relate to the question?)
- [x]  Is the code formatted well?
    > Run `CTRL` + `ALT` + `L` in IntelliJ
- [x]  EOF newlines
- [x]  Do the comments for Parsons follow the correct convention?
- [x]  Is the question being tested sufficiently?
    - [x]  Are there representative cases to test the program?
    - [x]  What about edge cases? (empty strings, negatives, infinity, off-by-one errors, etc)
        > If the question doesn’t specify what to do, mark it as a bad question
- [x]  Are the test method names good?
    > Test method names show up in a “What went well” section on the website, so “mathTest” will become “What went well: math test”, which doesn’t make much sense. A better name in this example would be “calculatesTaxCorrectly” so it shows up as “What went well: calculates tax correctly”
